### PR TITLE
bugfix: 修复不同长度的文章滚动到底部会闪屏

### DIFF
--- a/source/js/index.js
+++ b/source/js/index.js
@@ -340,8 +340,9 @@ if(window.isPost){
 
         reLayout()
 
-        window.addEventListener('scroll', (e) => {
-            reLayout()
+        window.addEventListener('scroll', function(e) {
+            let tocDom = document.querySelector('#toc')
+            window.scrollY < 550 ? tocDom.classList.remove('toc-fixed') : tocDom.classList.add('toc-fixed')
         })
     }
 }


### PR DESCRIPTION
用这主题看回以前的文章，不同长度的文章，滚动到底部会出现闪屏，上下上下的跳动