### PR TITLE
修复 在文章页面使用 permalink 强制制定url的时候无法正确导航

### DIFF
--- a/layout/index.ejs
+++ b/layout/index.ejs
@@ -7,7 +7,7 @@ layout: layout
     <div class="post-preview">
         <div class="post-time"><%= post.date.format(config.date_format) %></div>
         <div class="post-info">
-            <a href="<%- config.root %><%- post.path %>">
+            <a href="<%- full_url_for(post.path) %>">
                 <h3>
                     <%- (post.title || "Untitled").replace(/[<>&"]/g,function(c){
                         return {'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;'}[c];


### PR DESCRIPTION
如果写文章的时候这样覆盖强制绑定url
```
---
title: Hello World
url: http://xxx.com/
permalink: test.html
---
```
则出现无法正确导航，更换文章href 为 <%- full_url_for(post.path) %>